### PR TITLE
Include the "scheme" in self links

### DIFF
--- a/src/main/java/mx/nic/rdap/server/servlet/AutnumServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/AutnumServlet.java
@@ -45,7 +45,7 @@ public class AutnumServlet extends DataAccessServlet<AutnumDAO> {
 			return null;
 		}
 		
-		return new AutnumResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), autnum,
+		return new AutnumResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), autnum,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/AutnumServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/AutnumServlet.java
@@ -45,7 +45,7 @@ public class AutnumServlet extends DataAccessServlet<AutnumDAO> {
 			return null;
 		}
 		
-		return new AutnumResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), autnum,
+		return new AutnumResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), autnum,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/DomainSearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/DomainSearchServlet.java
@@ -76,7 +76,7 @@ public class DomainSearchServlet extends DataAccessServlet<DomainDAO> {
 			return null;
 		}
 
-		return new DomainSearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
+		return new DomainSearchResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), result, username);
 	}
 
 	private SearchResultStruct<Domain> getPartialSearch(String username, RdapSearchRequest request, DomainDAO dao)

--- a/src/main/java/mx/nic/rdap/server/servlet/DomainSearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/DomainSearchServlet.java
@@ -76,7 +76,7 @@ public class DomainSearchServlet extends DataAccessServlet<DomainDAO> {
 			return null;
 		}
 
-		return new DomainSearchResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
+		return new DomainSearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
 	}
 
 	private SearchResultStruct<Domain> getPartialSearch(String username, RdapSearchRequest request, DomainDAO dao)

--- a/src/main/java/mx/nic/rdap/server/servlet/DomainServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/DomainServlet.java
@@ -53,7 +53,7 @@ public class DomainServlet extends DataAccessServlet<DomainDAO> {
 			return null;
 		}
 
-		return new DomainResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), domain,
+		return new DomainResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), domain,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/DomainServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/DomainServlet.java
@@ -53,7 +53,7 @@ public class DomainServlet extends DataAccessServlet<DomainDAO> {
 			return null;
 		}
 
-		return new DomainResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), domain,
+		return new DomainResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), domain,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/EntitySearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/EntitySearchServlet.java
@@ -56,7 +56,7 @@ public class EntitySearchServlet extends DataAccessServlet<EntityDAO> {
 			return null;
 		}
 
-		return new EntitySearchResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
+		return new EntitySearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
 	}
 
 	private SearchResultStruct<Entity> getPartialSearch(String username, RdapSearchRequest searchRequest, EntityDAO dao)

--- a/src/main/java/mx/nic/rdap/server/servlet/EntitySearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/EntitySearchServlet.java
@@ -56,7 +56,7 @@ public class EntitySearchServlet extends DataAccessServlet<EntityDAO> {
 			return null;
 		}
 
-		return new EntitySearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result, username);
+		return new EntitySearchResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), result, username);
 	}
 
 	private SearchResultStruct<Entity> getPartialSearch(String username, RdapSearchRequest searchRequest, EntityDAO dao)

--- a/src/main/java/mx/nic/rdap/server/servlet/EntityServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/EntityServlet.java
@@ -44,7 +44,7 @@ public class EntityServlet extends DataAccessServlet<EntityDAO> {
 			return null;
 		}
 
-		return new EntityResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), entity,
+		return new EntityResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), entity,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/EntityServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/EntityServlet.java
@@ -44,7 +44,7 @@ public class EntityServlet extends DataAccessServlet<EntityDAO> {
 			return null;
 		}
 
-		return new EntityResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), entity,
+		return new EntityResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), entity,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/IpNetworkServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/IpNetworkServlet.java
@@ -67,7 +67,7 @@ public class IpNetworkServlet extends DataAccessServlet<IpNetworkDAO> {
 			return null;
 		}
 
-		return new IpResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), network,
+		return new IpResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), network,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/IpNetworkServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/IpNetworkServlet.java
@@ -67,7 +67,7 @@ public class IpNetworkServlet extends DataAccessServlet<IpNetworkDAO> {
 			return null;
 		}
 
-		return new IpResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), network,
+		return new IpResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), network,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/NameserverSearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/NameserverSearchServlet.java
@@ -71,7 +71,7 @@ public class NameserverSearchServlet extends DataAccessServlet<NameserverDAO> {
 			return null;
 		}
 
-		return new NameserverSearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result,
+		return new NameserverSearchResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), result,
 				username);
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/NameserverSearchServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/NameserverSearchServlet.java
@@ -71,7 +71,7 @@ public class NameserverSearchServlet extends DataAccessServlet<NameserverDAO> {
 			return null;
 		}
 
-		return new NameserverSearchResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), result,
+		return new NameserverSearchResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), result,
 				username);
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/NameserverServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/NameserverServlet.java
@@ -60,7 +60,7 @@ public class NameserverServlet extends DataAccessServlet<NameserverDAO> {
 			return null;
 		}
 
-		return new NameserverResult(httpRequest.getHeader("Host"), httpRequest.getContextPath(), nameserver,
+		return new NameserverResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), nameserver,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 

--- a/src/main/java/mx/nic/rdap/server/servlet/NameserverServlet.java
+++ b/src/main/java/mx/nic/rdap/server/servlet/NameserverServlet.java
@@ -60,7 +60,7 @@ public class NameserverServlet extends DataAccessServlet<NameserverDAO> {
 			return null;
 		}
 
-		return new NameserverResult(httpRequest.getScheme()+"://"+httpRequest.getHeader("Host"), httpRequest.getContextPath(), nameserver,
+		return new NameserverResult(Util.getServerUrl(httpRequest), httpRequest.getContextPath(), nameserver,
 				Util.getUsername(SecurityUtils.getSubject()));
 	}
 


### PR DESCRIPTION
Rdap self links do not include the "scheme" - the protocol prefix like http:// or https:// - so they are neither valid relative nor absolute links (referred to as suffix references in rfc 3986).  This PR adds the "scheme" and the "://" to each of the Servlets, as part of the variable called "header".  The header goes nowhere other than the Link object, so this seems to work well and maintain consistency.

This change is RFC compliant, and brings reddog in line with verisign rdap, as well as all the usual REST services.  The following is an example of a new links section:

      "links": [
        {
          "value": "https://example.com/entity/22-handle",
          "rel": "self",
          "href": "https://example.com/entity/22-handle",
          "type": "application/rdap+json"
        }
      ]

See also:
links section example includes scheme: https://tools.ietf.org/html/rfc7483#section-4.2
suffix references are discouraged: https://tools.ietf.org/html/rfc3986#section-4.5
verisign rdap example: https://rdap-pilot.verisignlabs.com/rdap/v1/entity/299~VRSN

